### PR TITLE
Improve logfuncdensity behavior and add isdensity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DensityInterface"
 uuid = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://github.com/JuliaMath/DensityInterface.jl/workflows/CI/badge.svg?branch=master)](https://github.com/JuliaMath/DensityInterface.jl/actions?query=workflow%3ACI)
 [![Codecov](https://codecov.io/gh/JuliaMath/DensityInterface.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaMath/DensityInterface.jl)
 
-This package defines an interface for mathematical/statistical densities in Julia. See the documentation for details.
+This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. See the documentation for details.
 
 
 ## Documentation

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,8 +13,9 @@ DocMeta.setdocmeta!(
     :DocTestSetup,
     quote
         using DensityInterface
-        d = logfuncdensity(x -> x^2)
+        d = logfuncdensity(x -> -x^2)
         log_f = logdensityof(d)
+        f = densityof(d)
         x = 4
     end;
     recursive=true,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,9 +13,9 @@ DocMeta.setdocmeta!(
     :DocTestSetup,
     quote
         using DensityInterface
-        d = logfuncdensity(x -> -x^2)
-        log_f = logdensityof(d)
-        f = densityof(d)
+        object = logfuncdensity(x -> -x^2)
+        log_f = logdensityof(object)
+        f = densityof(object)
         x = 4
     end;
     recursive=true,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,7 +3,8 @@
 ## Interface
 
 ```@docs
-densitykind
+isdensity
+hasdensity
 logdensityof
 logdensityof(::Any)
 logfuncdensity
@@ -15,10 +16,6 @@ densityof(::Any)
 ## Types
 
 ```@docs
-DensityKind
-HasNoDensity
-IsOrHasDensity
-IsDensity
 DensityInterface.LogFuncDensity
 DensityInterface.FuncDensity
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,10 +3,7 @@
 ## Interface
 
 ```@docs
-hasdensity
-ismeasure
-basemeasure
-isdensity
+densitykind
 logdensityof
 logdensityof(::Any)
 logfuncdensity
@@ -18,6 +15,10 @@ densityof(::Any)
 ## Types
 
 ```@docs
+DensityKind
+HasNoDensity
+IsOrHasDensity
+IsDensity
 DensityInterface.LogFuncDensity
 DensityInterface.FuncDensity
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,7 +3,6 @@
 ## Interface
 
 ```@docs
-densitykind
 logdensityof
 logdensityof(::Any)
 logfuncdensity

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,18 +4,22 @@
 
 ```@docs
 hasdensity
+ismeasure
+basemeasure
+isdensity
 logdensityof
 logdensityof(::Any)
 logfuncdensity
+funcdensity
 densityof
 densityof(::Any)
 ```
-
 
 ## Types
 
 ```@docs
 DensityInterface.LogFuncDensity
+DensityInterface.FuncDensity
 ```
 
 ## Test utility

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,8 +3,7 @@
 ## Interface
 
 ```@docs
-isdensity
-hasdensity
+densitykind
 logdensityof
 logdensityof(::Any)
 logfuncdensity
@@ -16,6 +15,11 @@ densityof(::Any)
 ## Types
 
 ```@docs
+IsDensity
+HasDensity
+IsOrHasDensity
+NoDensity
+DensityKind
 DensityInterface.LogFuncDensity
 DensityInterface.FuncDensity
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,6 +12,8 @@ end
 DensityInterface
 ```
 
+!!TODO - update text below in regard to measure theory; add basemeasure to docs text !!
+
 This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the functions [`hasdensity`](@ref),  [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref).
 
 The following methods must be provided to make a type (e.g. `SomeDensity`) compatible with the interface:
@@ -64,5 +66,5 @@ true
 
 [^1]: The function names `logdensityof` and `densityof` were chosen to convey that the target object may either *be* a density or something that can be said to *have* a density. They also have less naming conflict potential than `logdensity` and esp. `density` (the latter already being exported by Plots.jl).
 
-[^2]: The package [`MeasureTheory`](https://github.com/cscherrer/MeasureTheory.jl) provides tools to work with densities and measures that go beyond the density in 
+[^2]: !!TODO - Change Text!! The package [`MeasureTheory`](https://github.com/cscherrer/MeasureTheory.jl) provides tools to work with densities and measures that go beyond the density in 
 respect to an implied base measure.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,7 +19,7 @@ The following methods must be provided to make a type (e.g. `SomeDensity`) compa
 ```jldoctest a
 import DensityInterface
 
-@inline DensityInterface.densitykind(::SomeDensity) = IsDensity
+@inline DensityInterface.densitykind(::SomeDensity) = IsDensity()
 DensityInterface.logdensityof(object::SomeDensity, x) = log_of_d_at(x)
 
 object = SomeDensity()
@@ -30,7 +30,7 @@ DensityInterface.logdensityof(object, x) isa Real
 true
 ```
 
-`object` may be a density itself or something that can be said to have a density. If `object` is a distribution, the density is its probability density function. In the measure theoretical sense, the density function is the Radon–Nikodym derivative of `object` with respect to an implicit base measure. If `object` is not a density itself but has a density in this way, [`densitykind`](@ref) will not return [`IsDensity`](@ref) but another subtype of [`IsOrHasDensity`](@ref)[^1].
+`object` may be a density itself or something that can be said to have a density. If `object` is a distribution, the density is its probability density function. In the measure theoretical sense, the density function is the Radon–Nikodym derivative of `object` with respect to an implicit base measure. If `object` is not a density itself but has a density in this way, [`densitykind`](@ref) will not return [`IsDensity()`](@ref) but an instance of another subtype of [`IsOrHasDensity`](@ref)[^1].
 
 In statistical inference applications, for example, `object` might be a likelihood, prior or posterior[^2].
 
@@ -56,7 +56,7 @@ Reversely, a given log-density function `log_f` can be converted to a DensityInt
 
 ```julia
 object = logfuncdensity(log_f)
-densitykind(object) == IsDensity && logdensityof(object, x) == log_f(x)
+densitykind(object) == IsDensity() && logdensityof(object, x) == log_f(x)
 
 # output
 
@@ -66,4 +66,4 @@ true
 
 [^1]: The function names `logdensityof` and `densityof` were chosen to convey that the target object may either *be* a density or something that can be said to *have* a density. They also have less naming conflict potential than `logdensity` and esp. `density` (the latter already being exported by Plots.jl).
 
-[^2]: The packages [`MeasureBase`](https://github.com/cscherrer/MeasureBase.jl) and [`MeasureTheory`](https://github.com/cscherrer/MeasureTheory.jl) provide tools to work with densities and measures that go beyond the density in respect to an implied base measure. They also define additional subtypes of [`IsOrHasDensity`](@ref).
+[^2]: The packages [`MeasureBase`](https://github.com/cscherrer/MeasureBase.jl) and [`MeasureTheory`](https://github.com/cscherrer/MeasureTheory.jl) provide tools to work with densities and measures that go beyond the density in respect to an implied base measure.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,35 +12,36 @@ end
 DensityInterface
 ```
 
-!!TODO - update text below in regard to measure theory; add basemeasure to docs text !!
-
-This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the functions [`hasdensity`](@ref),  [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref).
+This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the functions [`densitykind`](@ref),  [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref)/[`funcdensity`](@ref).
 
 The following methods must be provided to make a type (e.g. `SomeDensity`) compatible with the interface:
 
 ```jldoctest a
 import DensityInterface
 
-DensityInterface.hasdensity(::SomeDensity) = true
-DensityInterface.logdensityof(d::SomeDensity, x) = log_of_d_at(x)
+@inline DensityInterface.densitykind(::SomeDensity) = IsDensity
+DensityInterface.logdensityof(object::SomeDensity, x) = log_of_d_at(x)
 
-DensityInterface.logdensityof(SomeDensity(), x) isa Real
+object = SomeDensity()
+DensityInterface.logdensityof(object, x) isa Real
 
 # output
 
 true
 ```
 
-The object `d` may be a density itself or something that can be said to have a density. If `d` is a distribution, the density is its probability density function. In the measure theoretical sense, the density function is the Radon–Nikodym derivative of `d` with respect to an implicit base measure. In statistical inference applications, for example, `d` might be a likelihood, prior or posterior[^2].
+`object` may be a density itself or something that can be said to have a density. If `object` is a distribution, the density is its probability density function. In the measure theoretical sense, the density function is the Radon–Nikodym derivative of `object` with respect to an implicit base measure. If `object` is not a density itself but has a density in this way, [`densitykind`](@ref) will not return [`IsDensity`](@ref) but another subtype of [`IsOrHasDensity`](@ref)[^1].
 
-DensityInterface automatically provides `logdensityof(d)`, equivalent to `x -> logdensityof(d, x)`. This constitutes a convenient way of passing a (log-)density function to algorithms like optimizers, samplers, etc.:
+In statistical inference applications, for example, `object` might be a likelihood, prior or posterior[^2].
+
+DensityInterface automatically provides `logdensityof(object)`, equivalent to `x -> logdensityof(object, x)`. This constitutes a convenient way of passing a (log-)density function to algorithms like optimizers, samplers, etc.:
 
 ```jldoctest a
 using DensityInterface
 
-d = SomeDensity()
-log_f = logdensityof(d)
-log_f(x) == logdensityof(d, x)
+object = SomeDensity()
+log_f = logdensityof(object)
+log_f(x) == logdensityof(object, x)
 
 # output
 
@@ -48,15 +49,14 @@ true
 ```
 
 ```julia
-SomeOptimizerPackage.maximize(logdensityof(d), x_init)
+SomeOptimizerPackage.maximize(logdensityof(object), x_init)
 ```
 
 Reversely, a given log-density function `log_f` can be converted to a DensityInterface-compatible density object using [`logfuncdensity`](@ref):
 
 ```julia
-d = logfuncdensity(log_f)
-hasdensity(d) == true
-logdensityof(d, x) == log_f(x)
+object = logfuncdensity(log_f)
+densitykind(object) == IsDensity && logdensityof(object, x) == log_f(x)
 
 # output
 
@@ -66,5 +66,4 @@ true
 
 [^1]: The function names `logdensityof` and `densityof` were chosen to convey that the target object may either *be* a density or something that can be said to *have* a density. They also have less naming conflict potential than `logdensity` and esp. `density` (the latter already being exported by Plots.jl).
 
-[^2]: !!TODO - Change Text!! The package [`MeasureTheory`](https://github.com/cscherrer/MeasureTheory.jl) provides tools to work with densities and measures that go beyond the density in 
-respect to an implied base measure.
+[^2]: The packages [`MeasureBase`](https://github.com/cscherrer/MeasureBase.jl) and [`MeasureTheory`](https://github.com/cscherrer/MeasureTheory.jl) provide tools to work with densities and measures that go beyond the density in respect to an implied base measure. They also define additional subtypes of [`IsOrHasDensity`](@ref).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,14 +12,14 @@ end
 DensityInterface
 ```
 
-This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the functions [`densitykind`](@ref),  [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref)/[`funcdensity`](@ref).
+This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the functions [`isdensity`](@ref), [`hasdensity`](@ref), [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref)/[`funcdensity`](@ref).
 
-The following methods must be provided to make a type (e.g. `SomeDensity`) compatible with the interface:
+The following methods must be provided to make a density type (e.g. `SomeDensity`) compatible with the interface:
 
 ```jldoctest a
 import DensityInterface
 
-@inline DensityInterface.densitykind(::SomeDensity) = IsDensity()
+@inline DensityInterface.isdensity(::SomeDensity) = true
 DensityInterface.logdensityof(object::SomeDensity, x) = log_of_d_at(x)
 
 object = SomeDensity()
@@ -30,9 +30,9 @@ DensityInterface.logdensityof(object, x) isa Real
 true
 ```
 
-`object` may be a density itself or something that can be said to have a density. If `object` is a distribution, the density is its probability density function. In the measure theoretical sense, the density function is the Radon–Nikodym derivative of `object` with respect to an implicit base measure. If `object` is not a density itself but has a density in this way, [`densitykind`](@ref) will not return [`IsDensity()`](@ref) but an instance of another subtype of [`IsOrHasDensity`](@ref)[^1].
+`object` may be/represent a density itself (`isdensity(object) == true`) or it may be something that can be said to have a density (`hasdensity(object) == true`)[^2].
 
-In statistical inference applications, for example, `object` might be a likelihood, prior or posterior[^2].
+In statistical inference applications, for example, `object` might be a likelihood, prior or posterior.
 
 DensityInterface automatically provides `logdensityof(object)`, equivalent to `x -> logdensityof(object, x)`. This constitutes a convenient way of passing a (log-)density function to algorithms like optimizers, samplers, etc.:
 
@@ -56,7 +56,7 @@ Reversely, a given log-density function `log_f` can be converted to a DensityInt
 
 ```julia
 object = logfuncdensity(log_f)
-densitykind(object) == IsDensity() && logdensityof(object, x) == log_f(x)
+isdensity(object) == true && logdensityof(object, x) == log_f(x)
 
 # output
 
@@ -66,4 +66,4 @@ true
 
 [^1]: The function names `logdensityof` and `densityof` were chosen to convey that the target object may either *be* a density or something that can be said to *have* a density. They also have less naming conflict potential than `logdensity` and esp. `density` (the latter already being exported by Plots.jl).
 
-[^2]: The packages [`MeasureBase`](https://github.com/cscherrer/MeasureBase.jl) and [`MeasureTheory`](https://github.com/cscherrer/MeasureTheory.jl) provide tools to work with densities and measures that go beyond the density in respect to an implied base measure.
+[^2]: The package [`Distributions`](https://github.com/JuliaStats/Distributions.jl) supports `DensityInterface` for `Distributions.Distribution`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,7 @@ Reversely, a given log-density function `log_f` can be converted to a DensityInt
 
 ```julia
 object = logfuncdensity(log_f)
-DensityKind(object) == IsDensity() && logdensityof(object, x) == log_f(x)
+DensityKind(object) === IsDensity() && logdensityof(object, x) == log_f(x)
 
 # output
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,7 @@ DensityInterface.logdensityof(object, x) isa Real
 true
 ```
 
-`object` may be/represent a density itself (`DensityKind(object) == IsDensity()`) or it may be something that can be said to have a density (`DensityKind(object) == HasDensity()`)[^2].
+`object` may be/represent a density itself (`DensityKind(object) === IsDensity()`) or it may be something that can be said to have a density (`DensityKind(object) === HasDensity()`)[^2].
 
 In statistical inference applications, for example, `object` might be a likelihood, prior or posterior.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,14 +12,14 @@ end
 DensityInterface
 ```
 
-This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the functions [`isdensity`](@ref), [`hasdensity`](@ref), [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref)/[`funcdensity`](@ref).
+This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the functions [`densitykind`](@ref),  [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref)/[`funcdensity`](@ref).
 
-The following methods must be provided to make a density type (e.g. `SomeDensity`) compatible with the interface:
+The following methods must be provided to make a type (e.g. `SomeDensity`) compatible with the interface:
 
 ```jldoctest a
 import DensityInterface
 
-@inline DensityInterface.isdensity(::SomeDensity) = true
+@inline DensityInterface.densitykind(::SomeDensity) = IsDensity()
 DensityInterface.logdensityof(object::SomeDensity, x) = log_of_d_at(x)
 
 object = SomeDensity()
@@ -30,7 +30,7 @@ DensityInterface.logdensityof(object, x) isa Real
 true
 ```
 
-`object` may be/represent a density itself (`isdensity(object) == true`) or it may be something that can be said to have a density (`hasdensity(object) == true`)[^2].
+`object` may be/represent a density itself (`densitykind(object) == IsDensity()`) or it may be something that can be said to have a density (`densitykind(object) == HasDensity()`)[^2].
 
 In statistical inference applications, for example, `object` might be a likelihood, prior or posterior.
 
@@ -56,7 +56,7 @@ Reversely, a given log-density function `log_f` can be converted to a DensityInt
 
 ```julia
 object = logfuncdensity(log_f)
-isdensity(object) == true && logdensityof(object, x) == log_f(x)
+densitykind(object) == IsDensity() && logdensityof(object, x) == log_f(x)
 
 # output
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,14 +12,14 @@ end
 DensityInterface
 ```
 
-This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the functions [`densitykind`](@ref),  [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref)/[`funcdensity`](@ref).
+This package defines an interface for mathematical/statistical densities and objects associated with a density in Julia. The interface comprises the type [`DensityKind`](@ref) and the functions [`logdensityof`](@ref)/[`densityof`](@ref)[^1] and [`logfuncdensity`](@ref)/[`funcdensity`](@ref).
 
 The following methods must be provided to make a type (e.g. `SomeDensity`) compatible with the interface:
 
 ```jldoctest a
 import DensityInterface
 
-@inline DensityInterface.densitykind(::SomeDensity) = IsDensity()
+@inline DensityInterface.DensityKind(::SomeDensity) = IsDensity()
 DensityInterface.logdensityof(object::SomeDensity, x) = log_of_d_at(x)
 
 object = SomeDensity()
@@ -30,7 +30,7 @@ DensityInterface.logdensityof(object, x) isa Real
 true
 ```
 
-`object` may be/represent a density itself (`densitykind(object) == IsDensity()`) or it may be something that can be said to have a density (`densitykind(object) == HasDensity()`)[^2].
+`object` may be/represent a density itself (`DensityKind(object) == IsDensity()`) or it may be something that can be said to have a density (`DensityKind(object) == HasDensity()`)[^2].
 
 In statistical inference applications, for example, `object` might be a likelihood, prior or posterior.
 
@@ -56,7 +56,7 @@ Reversely, a given log-density function `log_f` can be converted to a DensityInt
 
 ```julia
 object = logfuncdensity(log_f)
-densitykind(object) == IsDensity() && logdensityof(object, x) == log_f(x)
+DensityKind(object) == IsDensity() && logdensityof(object, x) == log_f(x)
 
 # output
 

--- a/src/DensityInterface.jl
+++ b/src/DensityInterface.jl
@@ -3,7 +3,8 @@
 """
     DensityInterface
 
-Trait-based interface for mathematical/statistical densities
+Trait-based interface for mathematical/statistical densities and objects
+associated with a density.
 """
 module DensityInterface
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,104 +2,100 @@
 
 
 """
-    struct IsDensity end
+    abstract type DensityKind end
 
-As a return value of [`densitykind(object)`](@ref), indicates that
-`object` *is* (represents) a density, like a probability density
-object.
+    DensityKind(object)
 
-See also [`logdensityof`](@ref) and [`densityof`](@ref).
-"""
-struct IsDensity end
-export IsDensity
-
-"""
-    struct HasDensity end
-
-As a return value of [`densitykind(object)`](@ref), indicates that
-`object` *has* a density, like a probability distribution has
-a probability density.
-
-See also [`logdensityof`](@ref) and [`densityof`](@ref).
-"""
-struct HasDensity end
-export HasDensity
-
-"""
-    IsOrHasDensity = Union{IsDensity, HasDensity}
-
-As a return value of [`densitykind(object)`](@ref), indicates that `object`
-either *is* or *has* a density, as understood by `DensityInterface`.
-
-See also [`IsDensity`](@ref) and [`IsDensity`](@ref).
-"""
-const IsOrHasDensity = Union{IsDensity, HasDensity}
-export IsOrHasDensity
-
-"""
-    struct NoDensity end
-
-As a return value of [`densitykind(object)`](@ref), indicates that
-`object` *is not* and *does not have* a density, as understood by
-`DensityInterface`.
-"""
-struct NoDensity end
-export NoDensity
-
-"""
-    DensityKind = Union{IsOrHasDensity, NoDensity}
-
-As a return value of [`densitykind(object)`](@ref), indicates that
-`object` is, resp. has, a density or that `object` is not
-associated with a density.
-
-See also [`IsOrHasDensity`](@ref) and [`NoDensity`](@ref).
-"""
-const DensityKind = Union{IsOrHasDensity, NoDensity}
-export DensityKind
-
-
-"""
-    densitykind(object)::DensityKind
-
-Tell if `object` *is* a density or if it *has* a density, in the sense of the
-`DensityInterface` API, or if is *not* associated with a density.
+Subtypes of `DensityKind` indicate if an `object` *is* a density or if it *has*
+a density, in the sense of the `DensityInterface` API, or if is *not*
+associated with a density (not compatible with `DensityInterface`).
     
-Return either `IsDensity()`, `HasDensity()` or `NoDensity()`
+`DensityKind(object)` returns either `IsDensity()`, `HasDensity()` or
+`NoDensity()`.
 
-In addition to [`IsDensity`](@ref), [`HasDensity`](@ref) or [`NoDensity`](@ref),
-two unions
+In addition to the subtypes [`IsDensity`](@ref), [`HasDensity`](@ref) or
+[`NoDensity`](@ref), a union `IsOrHasDensity = Union{IsDensity, HasDensity}`
+is defined for convenience.
 
-* `IsOrHasDensity = Union{IsDensity, HasDensity}`
-* `DensityKind = Union{IsOrHasDensity, NoDensity}`
+`DensityKind(object) isa IsOrHasDensity` implies that `object` is either a
+density itself or can be said to have an associated density. It also implies
+that the value of that density at given points can be calculated via
+[`logdensityof`](@ref) and [`densityof`](@ref).
 
-are defined for convenience. `densitykind(object) isa IsOrHasDensity` implies
-that `object` is either a density itself or can be said to have an associated
-density. It also implies that the value of that density at given points can be
-calculated via [`logdensityof`](@ref) and [`densityof`](@ref).
-
-Defaults to `NoDensity()`. For a type that *is* (directly represents)
-a density, like a probability density, define
+`DensityKind(object)` defaults to `NoDensity()` (object is not and does not
+have a density). For a type that *is* (directly represents) a density, like a
+probability density, define
 
 ```julia
-@inline densitykind(::MyDensityType) = IsDensity()
+@inline DensityKind(::MyDensityType) = IsDensity()
 ```
 
 For a type that *has* (is associated with) a density in some way, like
 a probability distribution has a probability density, define
 
 ```julia
-@inline densitykind(::MyDensityType) = HasDensity()
+@inline DensityKind(::MyDensityType) = HasDensity()
 ```
 """
-function densitykind end
-export densitykind
+abstract type DensityKind end
+export DensityKind
 
-@inline densitykind(object) = NoDensity()
+@inline DensityKind(object) = NoDensity()
+
+
+"""
+    struct IsDensity <: DensityKind end
+
+As a return value of [`DensityKind(object)`](@ref), indicates that
+`object` *is* (represents) a density, like a probability density
+object.
+
+See [`DensityKind`](@ref) for details.
+"""
+struct IsDensity end
+export IsDensity
+
+
+"""
+    struct HasDensity <: DensityKind end
+
+As a return value of [`DensityKind(object)`](@ref), indicates that
+`object` *has* a density, like a probability distribution has
+a probability density.
+
+See [`DensityKind`](@ref) for details.
+"""
+struct HasDensity end
+export HasDensity
+
+
+"""
+    struct NoDensity <: DensityKind end
+
+As a return value of [`DensityKind(object)`](@ref), indicates that
+`object` *is not* and *does not have* a density, as understood by
+`DensityInterface`.
+
+See [`DensityKind`](@ref) for details.
+"""
+struct NoDensity end
+export NoDensity
+
+
+"""
+    IsOrHasDensity = Union{IsDensity, HasDensity}
+
+As a return value of [`DensityKind(object)`](@ref), indicates that `object`
+either *is* or *has* a density, as understood by `DensityInterface`.
+
+See [`DensityKind`](@ref) for details.
+"""
+const IsOrHasDensity = Union{IsDensity, HasDensity}
+export IsOrHasDensity
 
 
 function _check_is_or_has_density(object)
-    densitykind(object) isa IsOrHasDensity || throw(ArgumentError("Object of type $(typeof(object)) neither is nor has a density"))
+    DensityKind(object) isa IsOrHasDensity || throw(ArgumentError("Object of type $(typeof(object)) neither is nor has a density"))
 end
 
 
@@ -110,14 +106,14 @@ Compute the logarithmic value of the density `object` (resp. its associated dens
 at a given point `x`.
 
 ```jldoctest a
-julia> densitykind(object)
+julia> DensityKind(object)
 IsDensity()
 
 julia> logy = logdensityof(object, x); logy isa Real
 true
 ```
 
-See also [`densitykind`](@ref) and [`densityof`](@ref).
+See also [`DensityKind`](@ref) and [`densityof`](@ref).
 """
 function logdensityof end
 export logdensityof
@@ -156,7 +152,7 @@ Compute the value of the density `object` (resp. its associated density)
 at a given point `x`.
     
 ```jldoctest a
-julia> densitykind(object)
+julia> DensityKind(object)
 IsDensity()
 
 julia> densityof(object, x) == exp(logdensityof(object, x))
@@ -166,7 +162,7 @@ true
 `densityof(object, x)` defaults to `exp(logdensityof(object, x))`, but
 may be specialized.
 
-See also [`densitykind`](@ref) and [`densityof`](@ref).
+See also [`DensityKind`](@ref) and [`densityof`](@ref).
 """
 densityof(object, x) = exp(logdensityof(object, x))
 export densityof
@@ -202,7 +198,7 @@ log-density function `log_f`:
 ```jldoctest
 julia> object = logfuncdensity(log_f);
 
-julia> densitykind(object)
+julia> DensityKind(object)
 IsDensity()
 
 julia> logdensityof(object, x) == log_f(x)
@@ -219,13 +215,13 @@ hold true:
 
 * `d = logfuncdensity(logdensityof(object))` is equivalent to `object` in
   respect to `logdensityof` and `densityof`. However, `d` may not be equal to
-  `object`, especially if `densitykind(object) == HasDensity()`: `logfuncdensity` always
+  `object`, especially if `DensityKind(object) == HasDensity()`: `logfuncdensity` always
   creates something that *is* density, never something that just *has*
   a density in some way (like a distribution or a measure in general).
 * `logdensityof(logfuncdensity(log_f))` is equivalent (typically equal or even
   identical to) to `log_f`.
 
-See also [`densitykind`](@ref).
+See also [`DensityKind`](@ref).
 """
 function logfuncdensity end
 export logfuncdensity
@@ -237,7 +233,7 @@ export logfuncdensity
 # For functions stemming from objects that *are* a density, recover original object:
 @inline _logfuncdensity_impl(::IsDensity, log_f::Base.Fix1{typeof(logdensityof)}) = log_f.x
 
-@inline logfuncdensity(log_f::Base.Fix1{typeof(logdensityof)}) = _logfuncdensity_impl(densitykind(log_f.x), log_f)
+@inline logfuncdensity(log_f::Base.Fix1{typeof(logdensityof)}) = _logfuncdensity_impl(DensityKind(log_f.x), log_f)
 
 InverseFunctions.inverse(::typeof(logfuncdensity)) = logdensityof
 InverseFunctions.inverse(::typeof(logdensityof)) = logfuncdensity
@@ -255,7 +251,7 @@ struct LogFuncDensity{F}
 end
 LogFuncDensity
 
-@inline densitykind(::LogFuncDensity) = IsDensity()
+@inline DensityKind(::LogFuncDensity) = IsDensity()
 
 @inline logdensityof(object::LogFuncDensity, x) = object._log_f(x)
 @inline logdensityof(object::LogFuncDensity) = object._log_f
@@ -280,7 +276,7 @@ non-log density function `f`:
 ```jldoctest
 julia> object = funcdensity(f);
 
-julia> densitykind(object)
+julia> DensityKind(object)
 IsDensity()
 
 julia> densityof(object, x) == f(x)
@@ -297,13 +293,13 @@ hold true:
 
 * `d = funcdensity(densityof(object))` is equivalent to `object` in
   respect to `logdensityof` and `densityof`. However, `d` may not be equal to
-  `object`, especially if `densitykind(object) == HasDensity()`: `funcdensity` always
+  `object`, especially if `DensityKind(object) == HasDensity()`: `funcdensity` always
   creates something that *is* density, never something that just *has*
   a density in some way (like a distribution or a measure in general).
 * `densityof(funcdensity(f))` is equivalent (typically equal or even
   identical to) to `f`.
 
-See also [`densitykind`](@ref).
+See also [`DensityKind`](@ref).
 """
 function funcdensity end
 export funcdensity
@@ -315,7 +311,7 @@ export funcdensity
 # For functions stemming from objects that *are* a density, recover original object:
 @inline _funcdensity_impl(::IsDensity, f::Base.Fix1{typeof(densityof)}) = f.x
 
-@inline funcdensity(f::Base.Fix1{typeof(densityof)}) = _funcdensity_impl(densitykind(f.x), f)
+@inline funcdensity(f::Base.Fix1{typeof(densityof)}) = _funcdensity_impl(DensityKind(f.x), f)
 
 InverseFunctions.inverse(::typeof(funcdensity)) = densityof
 InverseFunctions.inverse(::typeof(densityof)) = funcdensity
@@ -333,7 +329,7 @@ struct FuncDensity{F}
 end
 FuncDensity
 
-@inline densitykind(::FuncDensity) = IsDensity()
+@inline DensityKind(::FuncDensity) = IsDensity()
 
 @inline logdensityof(object::FuncDensity, x) = log(object._f(x))
 @inline logdensityof(object::FuncDensity) = log ∘ object._f

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -101,7 +101,7 @@ export logdensityof
     logdensityof(object)
 
 Return a function that computes the logarithmic value of the density `object`
-(resp. it's associated density) at a given point.
+(resp. its associated density) at a given point.
 
 ```jldoctest a
 julia> log_f = logdensityof(object); log_f isa Function

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -58,7 +58,7 @@ end
 """
     logdensityof(object, x)::Real
 
-Compute the logarithmic value of the density `object` (resp. it's associated density)
+Compute the logarithmic value of the density `object` (resp. its associated density)
 at a given point `x`.
 
 ```jldoctest a
@@ -104,7 +104,7 @@ end
 """
     densityof(object, x)::Real
 
-Compute the value of the density `object` (resp. it's associated density)
+Compute the value of the density `object` (resp. its associated density)
 at a given point `x`.
     
 ```jldoctest a
@@ -127,7 +127,7 @@ export densityof
     densityof(object)
 
 Return a function that computes the value of the density `object`
-(resp. it's associated density) at a given point.
+(resp. its associated density) at a given point.
         
 ```jldoctest a
 julia> f = densityof(object);

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -65,7 +65,7 @@ a probability density.
 
 See [`DensityKind`](@ref) for details.
 """
-struct HasDensity end
+struct HasDensity <: DensityKind end
 export HasDensity
 
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -52,7 +52,7 @@ object.
 
 See [`DensityKind`](@ref) for details.
 """
-struct IsDensity end
+struct IsDensity <: DensityKind end
 export IsDensity
 
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,25 +2,88 @@
 
 
 """
-    hasdensity(d)::Bool
+    ismeasure(object)::Bool
 
-Return `true` if `d` is compatible with the `DensityInterface` interface.
+Return `true` if `object` is a measure.
 
-`hasdensity(d) == true` implies that `d` is either a density itself or has an
-associated density, e.g. a probability density function or a Radon–Nikodym
+!!ToDo: More text!!
+
+Defaults to `false`. For types that are measures (not densities), define
+
+```julia
+@inline ismeasure(::MyMeasureType) = true
+```
+
+The above will automatically provide `hasdensity(::MyMeasureType) == true`.
+
+See also [`hasdensity`](@ref) and [`isdensity`](@ref).
+"""
+function ismeasure end
+export ismeasure
+
+@inline ismeasure(object) = false
+
+
+"""
+    hasdensity(object)::Bool
+
+Return `true` if `object` is compatible with the `DensityInterface` interface.
+
+`hasdensity(object) == true` implies that `object` is either a density itself or
+has an associated density, e.g. a probability density function or a Radon–Nikodym
 derivative with respect to an implicit base measure. It also implies that the
 value of that density at given points can be calculated via
 [`logdensityof`](@ref) and [`densityof`](@ref).
+
+Defaults to `ismeasure(object)`. For types that are densities, not measures,
+define
+
+```julia
+@inline hasdensity(::MyDensityType) = true
 ```
+
+See also [`ismeasure`](@ref) and [`isdensity`](@ref).
 """
 function hasdensity end
 export hasdensity
 
-@inline hasdensity(::Any) = false
+@inline hasdensity(object) = ismeasure(object)
 
 function check_hasdensity(d)
     hasdensity(d) || throw(ArgumentError("Object of type $(typeof(d)) is not compatible with DensityInterface"))
 end
+
+
+"""
+    isdensity(object) = hasdensity(object) && !ismeasure(object)
+
+Return `true` if `object` is a density. Defaults to
+`hasdensity(object) && !ismeasure(object)`.
+
+!!ToDo: More text!!
+
+`isdensity` should *not* be specialized, specialize [`ismeasure`](@ref) instead.
+
+See also [`hasdensity`](@ref).
+"""
+function isdensity end
+export isdensity
+
+@inline isdensity(object) = hasdensity(object) && !ismeasure(object)
+
+
+"""
+    basemeasure(m)
+
+Return the base measure of measure `m`.
+
+`logdensityof(m, x)` and `densityof(m, x)` return the log/non-log
+value of the Radon–Nikodym derivative of `m` and `basemeasure(m)`.
+
+!!ToDo: More text!!
+"""
+function basemeasure end
+export basemeasure
 
 
 """
@@ -70,71 +133,6 @@ end
 
 
 """
-    logfuncdensity(log_f)
-
-Return a `DensityInterface`-compatible density that is defined by a given
-log-density function `log_f`:
-
-```jldoctest
-julia> d = logfuncdensity(log_f);
-
-julia> hasdensity(d) == true
-true
-
-julia> logdensityof(d, x) == log_f(x)
-true
-```
-
-`logfuncdensity(log_f)` returns an instance of [`DensityInterface.LogFuncDensity`](@ref)
-by default, but may be specialized to return something else depending on the
-type of `log_f`). If so, [`logdensityof`](@ref) will typically have to be
-specialized for the return type of `logfuncdensity` as well.
-
-`logfuncdensity` is the inverse of `logdensityof`, so the following must
-hold true:
-
-* `logfuncdensity(logdensityof(d))` is equivalent to `d`
-* `logdensityof(logfuncdensity(log_f))` is equivalent to `log_f`.
-
-See also [`hasdensity`](@ref).
-"""
-function logfuncdensity end
-export logfuncdensity
-
-logfuncdensity(log_f) = LogFuncDensity(log_f)
-
-logfuncdensity(log_f::Base.Fix1{typeof(logdensityof)}) = log_f.x
-
-InverseFunctions.inverse(::typeof(logfuncdensity)) = logdensityof
-InverseFunctions.inverse(::typeof(logdensityof)) = logfuncdensity
-
-
-"""
-    struct DensityInterface.LogFuncDensity{F}
-
-Wraps a log-density function `log_f` to make it compatible with `DensityInterface`
-interface. Typically, `LogFuncDensity(log_f)` should not be called
-directly, [`logfuncdensity`](@ref) should be used instead.
-"""
-struct LogFuncDensity{F}
-    _log_f::F
-end
-LogFuncDensity
-
-@inline hasdensity(::LogFuncDensity) = true
-
-@inline logdensityof(d::LogFuncDensity, x) = d._log_f(x)
-@inline logdensityof(d::LogFuncDensity) = d._log_f
-
-function Base.show(io::IO, d::LogFuncDensity)
-    print(io, nameof(typeof(d)), "(")
-    show(io, d._log_f)
-    print(io, ")")
-end
-
-
-
-"""
     densityof(d, x)::Real
 
 Compute the value of density `d` or its associated density at a given point
@@ -174,4 +172,156 @@ true
 function densityof(d)
     check_hasdensity(d)
     Base.Fix1(densityof, d)
+end
+
+
+
+"""
+    logfuncdensity(log_f)
+
+Return a `DensityInterface`-compatible density that is defined by a given
+log-density function `log_f`:
+
+```jldoctest
+julia> d = logfuncdensity(log_f);
+
+julia> hasdensity(d) == true
+true
+
+julia> logdensityof(d, x) == log_f(x)
+true
+```
+
+`logfuncdensity(log_f)` returns an instance of [`DensityInterface.LogFuncDensity`](@ref)
+by default, but may be specialized to return something else depending on the
+type of `log_f`). If so, [`logdensityof`](@ref) will typically have to be
+specialized for the return type of `logfuncdensity` as well.
+
+`logfuncdensity` is the inverse of `logdensityof`, so the following must
+hold true:
+
+* `logfuncdensity(logdensityof(object))` is equivalent to `object` in respect to `logdensityof`.
+  However, it may not be equal to `object`, especially if `ismeasure(object) == true`:
+  `logfuncdensity` always creates a density, never a measure.
+* `logdensityof(logfuncdensity(log_f))` is equivalent  (often equal or even
+  identical to) to `log_f`.
+
+See also [`hasdensity`](@ref).
+"""
+function logfuncdensity end
+export logfuncdensity
+
+@inline logfuncdensity(log_f) = LogFuncDensity(log_f)
+
+# For functions stemming from measures create a density, not a measure:
+@inline _logfuncdensity_impl(::Val{true}, log_f::Base.Fix1{typeof(logdensityof)}) = LogFuncDensity(log_f)
+# For functions stemming from densities recover original density:
+@inline _logfuncdensity_impl(::Val{false}, log_f::Base.Fix1{typeof(logdensityof)}) = log_f.x
+
+@inline logfuncdensity(log_f::Base.Fix1{typeof(logdensityof)}) = _logfuncdensity_impl(Val(ismeasure(log_f.x)), log_f)
+
+InverseFunctions.inverse(::typeof(logfuncdensity)) = logdensityof
+InverseFunctions.inverse(::typeof(logdensityof)) = logfuncdensity
+
+
+"""
+    struct DensityInterface.LogFuncDensity{F}
+
+Wraps a log-density function `log_f` to make it compatible with `DensityInterface`
+interface. Typically, `LogFuncDensity(log_f)` should not be called
+directly, [`logfuncdensity`](@ref) should be used instead.
+"""
+struct LogFuncDensity{F}
+    _log_f::F
+end
+LogFuncDensity
+
+@inline hasdensity(::LogFuncDensity) = true
+
+@inline logdensityof(d::LogFuncDensity, x) = d._log_f(x)
+@inline logdensityof(d::LogFuncDensity) = d._log_f
+
+@inline densityof(d::LogFuncDensity, x) = exp(d._log_f(x))
+@inline densityof(d::LogFuncDensity) = exp ∘ d._log_f
+
+function Base.show(io::IO, d::LogFuncDensity)
+    print(io, nameof(typeof(d)), "(")
+    show(io, d._log_f)
+    print(io, ")")
+end
+
+
+
+"""
+    funcdensity(f)
+
+Return a `DensityInterface`-compatible density that is defined by a given
+non-log density function `f`:
+
+```jldoctest
+julia> d = funcdensity(f);
+
+julia> hasdensity(d) == true
+true
+
+julia> densityof(d, x) == f(x)
+true
+```
+
+`funcdensity(f)` returns an instance of [`DensityInterface.FuncDensity`](@ref)
+by default, but may be specialized to return something else depending on the
+type of `f`). If so, [`densityof`](@ref) will typically have to be
+specialized for the return type of `funcdensity` as well.
+
+`funcdensity` is the inverse of `densityof`, so the following must
+hold true:
+
+* `funcdensity(densityof(object))` is equivalent to `object` in respect to `densityof`.
+  However, it may not be equal to `object`, especially if `ismeasure(object) == true`:
+  `funcdensity` always creates a density, never a measure.
+* `densityof(funcdensity(f))` is equivalent (often equal or even
+  identical to) to `f`.
+
+See also [`hasdensity`](@ref).
+"""
+function funcdensity end
+export funcdensity
+
+@inline funcdensity(f) = FuncDensity(f)
+
+# For functions stemming from measures, create a density (not a measure):
+@inline _funcdensity_impl(::Val{true}, f::Base.Fix1{typeof(densityof)}) = FuncDensity(f)
+# For functions stemming from densities, recover original density:
+@inline _funcdensity_impl(::Val{false}, f::Base.Fix1{typeof(densityof)}) = f.x
+
+@inline funcdensity(f::Base.Fix1{typeof(densityof)}) = _funcdensity_impl(Val(ismeasure(f.x)), f)
+
+InverseFunctions.inverse(::typeof(funcdensity)) = densityof
+InverseFunctions.inverse(::typeof(densityof)) = funcdensity
+
+
+"""
+    struct DensityInterface.FuncDensity{F}
+
+Wraps a non-log density function `f` to make it compatible with
+`DensityInterface` interface. Typically, `FuncDensity(f)` should not be
+called directly, [`funcdensity`](@ref) should be used instead.
+"""
+struct FuncDensity{F}
+    _f::F
+end
+FuncDensity
+
+@inline hasdensity(::FuncDensity) = true
+
+@inline logdensityof(d::FuncDensity, x) = log(d._f(x))
+@inline logdensityof(d::FuncDensity) = log ∘ d._f
+
+@inline densityof(d::FuncDensity, x) = d._f(x)
+@inline densityof(d::FuncDensity) = d._f
+
+function Base.show(io::IO, d::FuncDensity)
+    print(io, nameof(typeof(d)), "(")
+    show(io, d._f)
+    print(io, ")")
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -78,7 +78,7 @@ export isdensity
 Return the base measure of measure `m`.
 
 `logdensityof(m, x)` and `densityof(m, x)` return the log/non-log
-value of the Radon–Nikodym derivative of `m` and `basemeasure(m)`.
+Radon–Nikodym derivative of `m` with respect to `basemeasure(m)` evaluated at `x`.
 
 !!ToDo: More text!!
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -78,7 +78,7 @@ As a return value of [`DensityKind(object)`](@ref), indicates that
 
 See [`DensityKind`](@ref) for details.
 """
-struct NoDensity end
+struct NoDensity <: DensityKind end
 export NoDensity
 
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,9 +2,33 @@
 
 
 """
-    hasdensity(object)::Bool
+    isdensity(d)::Bool
 
 Return `true` if `d` is a density.
+
+`isdensity(d) == true` means that `d` itself is/represents a density. It also
+implies that the value of the density `d` at given points can be calculated
+via [`logdensityof`](@ref) and [`densityof`](@ref).
+
+Defaults to `false`. For types that are/represent a density, define
+
+```julia
+@inline isdensity(::MyType) = true
+```
+
+`isdensity` and [`hasdensity`](@ref) *must not* both return true for the
+same object.
+"""
+function isdensity end
+export isdensity
+
+@inline isdensity(::Any) = false
+
+
+"""
+    hasdensity(object)::Bool
+
+Return `true` if `d` has a density.
 
 `hasdensity(object) == true` means that `d` can be said to have an associated
 density. It also implies that the value of that density at given points can
@@ -24,30 +48,6 @@ function hasdensity end
 export hasdensity
 
 @inline hasdensity(::Any) = false
-
-
-"""
-    isdensity(d)::Bool
-
-Return `true` if `d` has a density.
-
-`isdensity(d) == true` means that `d` itself is/represents a density. It also
-implies that the value of the density `d` at given points can be calculated
-via [`logdensityof`](@ref) and [`densityof`](@ref).
-
-Defaults to `false`. For types that are/represent a density, define
-
-```julia
-@inline isdensity(::MyType) = true
-```
-
-`isdensity` and [`hasdensity`](@ref) *must not* both return true for the
-same object.
-"""
-function isdensity end
-export isdensity
-
-@inline isdensity(::Any) = false
 
 
 function _check_is_or_has_density(d)

--- a/src/interface_test.jl
+++ b/src/interface_test.jl
@@ -5,8 +5,7 @@
 
 Test that `object` is compatible with `DensityInterface`.
 
-Tests that either `isdensity(object)` or `hasdensity(object)` are true, but
-not both of them.
+Tests that either `densitykind(object) isa IsOrHasDensity`.
 
 Also tests that [`logdensityof(object, x)`](@ref) equals `ref_logd_at_x` and
 that the behavior of [`logdensityof(object)`](@ref),
@@ -17,7 +16,7 @@ The results of `logdensityof(object, x)` and `densityof(object, x)` are compared
 forwarded to `isapprox`.
 
 Also tests that `d = logfuncdensity(logdensityof(object))` returns a density
-(`isdensity(d) == true`) that is equivalent to `object` in respect to
+(`densitykind(d) == IsDensity()`) that is equivalent to `object` in respect to
 `logdensityof` and `densityof`, and that `funcdensity(densityof(object))`
 behaves the same way.
 """
@@ -25,7 +24,7 @@ function test_density_interface(object, x, ref_logd_at_x; kwargs...)
     @testset "test_density_interface: $object with input $x" begin
         ref_d_at_x = exp(ref_logd_at_x)
 
-        @test isdensity(object) ⊻ hasdensity(object)
+        @test densitykind(object) isa IsOrHasDensity
 
         @test isapprox(logdensityof(object, x), ref_logd_at_x; kwargs...)
         log_f = logdensityof(object)
@@ -35,12 +34,12 @@ function test_density_interface(object, x, ref_logd_at_x; kwargs...)
         f = densityof(object)
         @test isapprox(f(x), ref_d_at_x; kwargs...)
 
-        for object2 in (logfuncdensity(log_f), funcdensity(f))
-            @test isdensity(object2) == true && hasdensity(object2) == false
-            @test isapprox(logdensityof(object2, x), ref_logd_at_x; kwargs...)
-            @test isapprox(logdensityof(object2)(x), ref_logd_at_x; kwargs...)
-            @test isapprox(densityof(object2,x), ref_d_at_x; kwargs...)
-            @test isapprox(densityof(object2)(x), ref_d_at_x; kwargs...)
+        for d in (logfuncdensity(log_f), funcdensity(f))
+            @test densitykind(d) == IsDensity()
+            @test isapprox(logdensityof(d, x), ref_logd_at_x; kwargs...)
+            @test isapprox(logdensityof(d)(x), ref_logd_at_x; kwargs...)
+            @test isapprox(densityof(d,x), ref_d_at_x; kwargs...)
+            @test isapprox(densityof(d)(x), ref_d_at_x; kwargs...)
         end
     end
 end

--- a/src/interface_test.jl
+++ b/src/interface_test.jl
@@ -1,43 +1,41 @@
 # This file is a part of DensityInterface.jl, licensed under the MIT License (MIT).
 
 """
-    DensityInterface.test_density_interface(o, x, ref_logd_at_x; kwargs...)
+    DensityInterface.test_density_interface(object, x, ref_logd_at_x; kwargs...)
 
-Test if `o` is compatible with `DensityInterface`.
+Test if `object` is compatible with `DensityInterface`.
 
-Tests that [`logdensityof(o, x)`](@ref) equals `ref_logd_at_x` and
-that the behavior of [`logdensityof(o)`](@ref),
-[`densityof(o, x)`](@ref) and [`densityof(o)`](@ref) is consistent.
+Tests that [`logdensityof(object, x)`](@ref) equals `ref_logd_at_x` and
+that the behavior of [`logdensityof(object)`](@ref),
+[`densityof(object, x)`](@ref) and [`densityof(object)`](@ref) is consistent.
 
-Also tests if `logfuncdensity(logdensityof(o))` returns
-a density equivalent to `o` in respect to the functions above.
+Also tests if `logfuncdensity(logdensityof(object))` returns
+a density equivalent to `object` in respect to the functions above.
 
-The results of `logdensityof(o, x)` and `densityof(o, x)` are compared to
+The results of `logdensityof(object, x)` and `densityof(object, x)` are compared to
 `ref_logd_at_x` and `exp(ref_logd_at_x)` using `isapprox`. `kwargs...` are
 forwarded to `isapprox`.
 """
-function test_density_interface(o, x, ref_logd_at_x; kwargs...)
-    @testset "test_density_interface: $o with input $x" begin
+function test_density_interface(object, x, ref_logd_at_x; kwargs...)
+    @testset "test_density_interface: $object with input $x" begin
         ref_d_at_x = exp(ref_logd_at_x)
 
-        @test hasdensity(o)
-        @test isdensity(o) ⊻ ismeasure(o)
+        @test densitykind(object) <: IsOrHasDensity
 
-        @test isapprox(logdensityof(o, x), ref_logd_at_x; kwargs...)
-        log_f = logdensityof(o)
+        @test isapprox(logdensityof(object, x), ref_logd_at_x; kwargs...)
+        log_f = logdensityof(object)
         @test isapprox(log_f(x), ref_logd_at_x; kwargs...)
 
-        @test isapprox(densityof(o,x), ref_d_at_x; kwargs...)
-        f = densityof(o)
+        @test isapprox(densityof(object,x), ref_d_at_x; kwargs...)
+        f = densityof(object)
         @test isapprox(f(x), ref_d_at_x; kwargs...)
 
-        for o2 in (logfuncdensity(log_f), funcdensity(f))
-            @test hasdensity(o2)
-            @test isdensity(o2) && !ismeasure(o2)
-            @test isapprox(logdensityof(o2, x), ref_logd_at_x; kwargs...)
-            @test isapprox(logdensityof(o2)(x), ref_logd_at_x; kwargs...)
-            @test isapprox(densityof(o2,x), ref_d_at_x; kwargs...)
-            @test isapprox(densityof(o2)(x), ref_d_at_x; kwargs...)
+        for object2 in (logfuncdensity(log_f), funcdensity(f))
+            @test densitykind(object2) <: IsDensity
+            @test isapprox(logdensityof(object2, x), ref_logd_at_x; kwargs...)
+            @test isapprox(logdensityof(object2)(x), ref_logd_at_x; kwargs...)
+            @test isapprox(densityof(object2,x), ref_d_at_x; kwargs...)
+            @test isapprox(densityof(object2)(x), ref_d_at_x; kwargs...)
         end
     end
 end

--- a/src/interface_test.jl
+++ b/src/interface_test.jl
@@ -3,24 +3,29 @@
 """
     DensityInterface.test_density_interface(object, x, ref_logd_at_x; kwargs...)
 
-Test if `object` is compatible with `DensityInterface`.
+Test that `object` is compatible with `DensityInterface`.
 
-Tests that [`logdensityof(object, x)`](@ref) equals `ref_logd_at_x` and
+Tests that either `isdensity(object)` or `hasdensity(object)` are true, but
+not both of them.
+
+Also tests that [`logdensityof(object, x)`](@ref) equals `ref_logd_at_x` and
 that the behavior of [`logdensityof(object)`](@ref),
 [`densityof(object, x)`](@ref) and [`densityof(object)`](@ref) is consistent.
-
-Also tests if `logfuncdensity(logdensityof(object))` returns
-a density equivalent to `object` in respect to the functions above.
 
 The results of `logdensityof(object, x)` and `densityof(object, x)` are compared to
 `ref_logd_at_x` and `exp(ref_logd_at_x)` using `isapprox`. `kwargs...` are
 forwarded to `isapprox`.
+
+Also tests that `d = logfuncdensity(logdensityof(object))` returns a density
+(`isdensity(d) == true`) that is equivalent to `object` in respect to
+`logdensityof` and `densityof`, and that `funcdensity(densityof(object))`
+behaves the same way.
 """
 function test_density_interface(object, x, ref_logd_at_x; kwargs...)
     @testset "test_density_interface: $object with input $x" begin
         ref_d_at_x = exp(ref_logd_at_x)
 
-        @test densitykind(object) isa IsOrHasDensity
+        @test isdensity(object) ⊻ hasdensity(object)
 
         @test isapprox(logdensityof(object, x), ref_logd_at_x; kwargs...)
         log_f = logdensityof(object)
@@ -31,7 +36,7 @@ function test_density_interface(object, x, ref_logd_at_x; kwargs...)
         @test isapprox(f(x), ref_d_at_x; kwargs...)
 
         for object2 in (logfuncdensity(log_f), funcdensity(f))
-            @test densitykind(object2) == IsDensity()
+            @test isdensity(object2) == true && hasdensity(object2) == false
             @test isapprox(logdensityof(object2, x), ref_logd_at_x; kwargs...)
             @test isapprox(logdensityof(object2)(x), ref_logd_at_x; kwargs...)
             @test isapprox(densityof(object2,x), ref_d_at_x; kwargs...)

--- a/src/interface_test.jl
+++ b/src/interface_test.jl
@@ -1,38 +1,43 @@
 # This file is a part of DensityInterface.jl, licensed under the MIT License (MIT).
 
 """
-    DensityInterface.test_density_interface(d, x, ref_logd_at_x; kwargs...)
+    DensityInterface.test_density_interface(o, x, ref_logd_at_x; kwargs...)
 
-Test if `d` is compatible with `DensityInterface`.
+Test if `o` is compatible with `DensityInterface`.
 
-Tests that [`logdensityof(d, x)`](@ref) equals `ref_logd_at_x` and
-that the behavior of [`logdensityof(d)`](@ref),
-[`densityof(d, x)`](@ref) and [`densityof(d)`](@ref) is consistent.
+Tests that [`logdensityof(o, x)`](@ref) equals `ref_logd_at_x` and
+that the behavior of [`logdensityof(o)`](@ref),
+[`densityof(o, x)`](@ref) and [`densityof(o)`](@ref) is consistent.
 
-Also tests if `logfuncdensity(logdensityof(d))` returns
-a density equivalent to `d` in respect to the functions above.
+Also tests if `logfuncdensity(logdensityof(o))` returns
+a density equivalent to `o` in respect to the functions above.
 
-The results of `logdensityof(d, x)` and `densityof(d, x)` are compared to
+The results of `logdensityof(o, x)` and `densityof(o, x)` are compared to
 `ref_logd_at_x` and `exp(ref_logd_at_x)` using `isapprox`. `kwargs...` are
 forwarded to `isapprox`.
 """
-function test_density_interface(d, x, ref_logd_at_x; kwargs...)
-    @testset "test_density_interface: $d with input $x" begin
+function test_density_interface(o, x, ref_logd_at_x; kwargs...)
+    @testset "test_density_interface: $o with input $x" begin
         ref_d_at_x = exp(ref_logd_at_x)
 
-        @test hasdensity(d) == true
-        @test isapprox(logdensityof(d, x), ref_logd_at_x; kwargs...)
-        log_f = logdensityof(d)
-        @test isapprox(log_f(x), ref_logd_at_x; kwargs...)
-        @test isapprox(densityof(d,x), ref_d_at_x; kwargs...)
-        @test isapprox(densityof(d)(x), ref_d_at_x; kwargs...)
+        @test hasdensity(o)
+        @test isdensity(o) ⊻ ismeasure(o)
 
-        d2 = logfuncdensity(log_f)
-        @test hasdensity(d2) == true
-        @test isapprox(logdensityof(d2, x), ref_logd_at_x; kwargs...)
-        log_f2 = logdensityof(d2)
-        @test isapprox(log_f2(x), ref_logd_at_x; kwargs...)
-        @test isapprox(densityof(d2,x), ref_d_at_x; kwargs...)
-        @test isapprox(densityof(d2)(x), ref_d_at_x; kwargs...)
+        @test isapprox(logdensityof(o, x), ref_logd_at_x; kwargs...)
+        log_f = logdensityof(o)
+        @test isapprox(log_f(x), ref_logd_at_x; kwargs...)
+
+        @test isapprox(densityof(o,x), ref_d_at_x; kwargs...)
+        f = densityof(o)
+        @test isapprox(f(x), ref_d_at_x; kwargs...)
+
+        for o2 in (logfuncdensity(log_f), funcdensity(f))
+            @test hasdensity(o2)
+            @test isdensity(o2) && !ismeasure(o2)
+            @test isapprox(logdensityof(o2, x), ref_logd_at_x; kwargs...)
+            @test isapprox(logdensityof(o2)(x), ref_logd_at_x; kwargs...)
+            @test isapprox(densityof(o2,x), ref_d_at_x; kwargs...)
+            @test isapprox(densityof(o2)(x), ref_d_at_x; kwargs...)
+        end
     end
 end

--- a/src/interface_test.jl
+++ b/src/interface_test.jl
@@ -5,7 +5,7 @@
 
 Test that `object` is compatible with `DensityInterface`.
 
-Tests that either `densitykind(object) isa IsOrHasDensity`.
+Tests that either `DensityKind(object) isa IsOrHasDensity`.
 
 Also tests that [`logdensityof(object, x)`](@ref) equals `ref_logd_at_x` and
 that the behavior of [`logdensityof(object)`](@ref),
@@ -16,7 +16,7 @@ The results of `logdensityof(object, x)` and `densityof(object, x)` are compared
 forwarded to `isapprox`.
 
 Also tests that `d = logfuncdensity(logdensityof(object))` returns a density
-(`densitykind(d) == IsDensity()`) that is equivalent to `object` in respect to
+(`DensityKind(d) == IsDensity()`) that is equivalent to `object` in respect to
 `logdensityof` and `densityof`, and that `funcdensity(densityof(object))`
 behaves the same way.
 """
@@ -24,7 +24,7 @@ function test_density_interface(object, x, ref_logd_at_x; kwargs...)
     @testset "test_density_interface: $object with input $x" begin
         ref_d_at_x = exp(ref_logd_at_x)
 
-        @test densitykind(object) isa IsOrHasDensity
+        @test DensityKind(object) isa IsOrHasDensity
 
         @test isapprox(logdensityof(object, x), ref_logd_at_x; kwargs...)
         log_f = logdensityof(object)
@@ -35,7 +35,7 @@ function test_density_interface(object, x, ref_logd_at_x; kwargs...)
         @test isapprox(f(x), ref_d_at_x; kwargs...)
 
         for d in (logfuncdensity(log_f), funcdensity(f))
-            @test densitykind(d) == IsDensity()
+            @test DensityKind(d) == IsDensity()
             @test isapprox(logdensityof(d, x), ref_logd_at_x; kwargs...)
             @test isapprox(logdensityof(d)(x), ref_logd_at_x; kwargs...)
             @test isapprox(densityof(d,x), ref_d_at_x; kwargs...)

--- a/src/interface_test.jl
+++ b/src/interface_test.jl
@@ -20,7 +20,7 @@ function test_density_interface(object, x, ref_logd_at_x; kwargs...)
     @testset "test_density_interface: $object with input $x" begin
         ref_d_at_x = exp(ref_logd_at_x)
 
-        @test densitykind(object) <: IsOrHasDensity
+        @test densitykind(object) isa IsOrHasDensity
 
         @test isapprox(logdensityof(object, x), ref_logd_at_x; kwargs...)
         log_f = logdensityof(object)
@@ -31,7 +31,7 @@ function test_density_interface(object, x, ref_logd_at_x; kwargs...)
         @test isapprox(f(x), ref_d_at_x; kwargs...)
 
         for object2 in (logfuncdensity(log_f), funcdensity(f))
-            @test densitykind(object2) <: IsDensity
+            @test densitykind(object2) == IsDensity()
             @test isapprox(logdensityof(object2, x), ref_logd_at_x; kwargs...)
             @test isapprox(logdensityof(object2)(x), ref_logd_at_x; kwargs...)
             @test isapprox(densityof(object2,x), ref_d_at_x; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ Test.@testset "Package DensityInterface" begin
             using DensityInterface
             d = logfuncdensity(x -> x^2)
             log_f = logdensityof(d)
+            f = densityof(d)
             x = 4.2
         end;
             recursive=true,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,9 +13,9 @@ Test.@testset "Package DensityInterface" begin
         :DocTestSetup,
         quote
             using DensityInterface
-            d = logfuncdensity(x -> x^2)
-            log_f = logdensityof(d)
-            f = densityof(d)
+            object = logfuncdensity(x -> x^2)
+            log_f = logdensityof(object)
+            f = densityof(object)
             x = 4.2
         end;
             recursive=true,

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -6,8 +6,12 @@ using Test
 using LinearAlgebra, InverseFunctions
 
 struct MyDensity end
-@inline DensityInterface.densitykind(::MyDensity) = IsDensity()
+@inline DensityInterface.isdensity(::MyDensity) = true
 DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
+
+struct MyMeasure end
+@inline DensityInterface.hasdensity(::MyMeasure) = true
+DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
 
 @testset "interface" begin
     @test inverse(logdensityof) == logfuncdensity
@@ -15,22 +19,23 @@ DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
     @test inverse(densityof) == funcdensity
     @test inverse(funcdensity) == densityof
 
-    @test @inferred(densitykind("foo")) == HasNoDensity()
+    @test @inferred(isdensity("foo")) == false
+    @test @inferred(hasdensity("foo")) == false
     @test_throws ArgumentError logdensityof("foo")
     @test_throws ArgumentError densityof("foo")
 
-    d1 = MyDensity()
-    @test @inferred(densitykind(d1)) == IsDensity()
-    x = [1, 2, 3]
-    DensityInterface.test_density_interface(d1, x, -norm(x)^2)
+    for object1 in (MyDensity(), MyMeasure())
+        x = [1, 2, 3]
 
-    d2 = logfuncdensity(x -> -norm(x)^2)
-    @test @inferred(densitykind(d2)) == IsDensity()
-    x = [1, 2, 3]
-    DensityInterface.test_density_interface(d2, x, -norm(x)^2)
+        object1 = MyDensity()
+        DensityInterface.test_density_interface(object1, x, -norm(x)^2)
 
-    d3 = funcdensity(x -> exp(-norm(x)^2))
-    @test @inferred(densitykind(d3)) == IsDensity()
-    x = [1, 2, 3]
-    DensityInterface.test_density_interface(d3, x, -norm(x)^2)
+        object2 = logfuncdensity(x -> -norm(x)^2)
+        @test isdensity(object2)
+        DensityInterface.test_density_interface(object2, x, -norm(x)^2)
+
+        object3 = funcdensity(x -> exp(-norm(x)^2))
+        @test isdensity(object3)
+        DensityInterface.test_density_interface(object3, x, -norm(x)^2)
+    end
 end

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -33,7 +33,7 @@ DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
         DensityInterface.test_density_interface(object2, x, -norm(x)^2)
 
         object3 = funcdensity(x -> exp(-norm(x)^2))
-        @test DensityKind(object3) == IsDensity()
+        @test DensityKind(object3) === IsDensity()
         DensityInterface.test_density_interface(object3, x, -norm(x)^2)
     end
 end

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -27,7 +27,6 @@ DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
     for object1 in (MyDensity(), MyMeasure())
         x = [1, 2, 3]
 
-        object1 = MyDensity()
         DensityInterface.test_density_interface(object1, x, -norm(x)^2)
 
         object2 = logfuncdensity(x -> -norm(x)^2)

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -19,7 +19,7 @@ DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
     @test inverse(densityof) == funcdensity
     @test inverse(funcdensity) == densityof
 
-    @test @inferred(DensityKind("foo")) == NoDensity()
+    @test @inferred(DensityKind("foo")) === NoDensity()
     @test_throws ArgumentError logdensityof("foo")
     @test_throws ArgumentError densityof("foo")
 

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -6,11 +6,11 @@ using Test
 using LinearAlgebra, InverseFunctions
 
 struct MyDensity end
-@inline DensityInterface.densitykind(::MyDensity) = IsDensity()
+@inline DensityInterface.DensityKind(::MyDensity) = IsDensity()
 DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
 
 struct MyMeasure end
-@inline DensityInterface.densitykind(::MyMeasure) = HasDensity()
+@inline DensityInterface.DensityKind(::MyMeasure) = HasDensity()
 DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
 
 @testset "interface" begin
@@ -19,7 +19,7 @@ DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
     @test inverse(densityof) == funcdensity
     @test inverse(funcdensity) == densityof
 
-    @test @inferred(densitykind("foo")) == NoDensity()
+    @test @inferred(DensityKind("foo")) == NoDensity()
     @test_throws ArgumentError logdensityof("foo")
     @test_throws ArgumentError densityof("foo")
 
@@ -29,11 +29,11 @@ DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
         DensityInterface.test_density_interface(object1, x, -norm(x)^2)
 
         object2 = logfuncdensity(x -> -norm(x)^2)
-        @test densitykind(object2) == IsDensity()
+        @test DensityKind(object2) == IsDensity()
         DensityInterface.test_density_interface(object2, x, -norm(x)^2)
 
         object3 = funcdensity(x -> exp(-norm(x)^2))
-        @test densitykind(object3) == IsDensity()
+        @test DensityKind(object3) == IsDensity()
         DensityInterface.test_density_interface(object3, x, -norm(x)^2)
     end
 end

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -6,11 +6,11 @@ using Test
 using LinearAlgebra, InverseFunctions
 
 struct MyDensity end
-@inline DensityInterface.isdensity(::MyDensity) = true
+@inline DensityInterface.densitykind(::MyDensity) = IsDensity()
 DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
 
 struct MyMeasure end
-@inline DensityInterface.hasdensity(::MyMeasure) = true
+@inline DensityInterface.densitykind(::MyMeasure) = HasDensity()
 DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
 
 @testset "interface" begin
@@ -19,8 +19,7 @@ DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
     @test inverse(densityof) == funcdensity
     @test inverse(funcdensity) == densityof
 
-    @test @inferred(isdensity("foo")) == false
-    @test @inferred(hasdensity("foo")) == false
+    @test @inferred(densitykind("foo")) == NoDensity()
     @test_throws ArgumentError logdensityof("foo")
     @test_throws ArgumentError densityof("foo")
 
@@ -30,11 +29,11 @@ DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
         DensityInterface.test_density_interface(object1, x, -norm(x)^2)
 
         object2 = logfuncdensity(x -> -norm(x)^2)
-        @test isdensity(object2)
+        @test densitykind(object2) == IsDensity()
         DensityInterface.test_density_interface(object2, x, -norm(x)^2)
 
         object3 = funcdensity(x -> exp(-norm(x)^2))
-        @test isdensity(object3)
+        @test densitykind(object3) == IsDensity()
         DensityInterface.test_density_interface(object3, x, -norm(x)^2)
     end
 end

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -5,10 +5,8 @@ using Test
 
 using LinearAlgebra, InverseFunctions
 
-# !!TODO: Add tests for measures!!
-
 struct MyDensity end
-@inline DensityInterface.hasdensity(::MyDensity) = true
+@inline DensityInterface.densitykind(::MyDensity) = IsDensity
 DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
 
 @testset "interface" begin
@@ -17,27 +15,22 @@ DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
     @test inverse(densityof) == funcdensity
     @test inverse(funcdensity) == densityof
 
-    @test @inferred(hasdensity("foo")) == false
-    @test @inferred(ismeasure("foo")) == false
-    @test @inferred(isdensity("foo")) == false
+    @test @inferred(densitykind("foo")) == HasNoDensity
     @test_throws ArgumentError logdensityof("foo")
     @test_throws ArgumentError densityof("foo")
 
     d1 = MyDensity()
-    @test @inferred(ismeasure(d1)) == false
-    @test @inferred(isdensity(d1)) == true
+    @test @inferred(densitykind(d1)) == IsDensity
     x = [1, 2, 3]
     DensityInterface.test_density_interface(d1, x, -norm(x)^2)
 
     d2 = logfuncdensity(x -> -norm(x)^2)
-    @test @inferred(ismeasure(d2)) == false
-    @test @inferred(isdensity(d2)) == true
+    @test @inferred(densitykind(d2)) == IsDensity
     x = [1, 2, 3]
     DensityInterface.test_density_interface(d2, x, -norm(x)^2)
 
     d3 = funcdensity(x -> exp(-norm(x)^2))
-    @test @inferred(ismeasure(d3)) == false
-    @test @inferred(isdensity(d3)) == true
+    @test @inferred(densitykind(d3)) == IsDensity
     x = [1, 2, 3]
     DensityInterface.test_density_interface(d3, x, -norm(x)^2)
 end

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -6,7 +6,7 @@ using Test
 using LinearAlgebra, InverseFunctions
 
 struct MyDensity end
-@inline DensityInterface.densitykind(::MyDensity) = IsDensity
+@inline DensityInterface.densitykind(::MyDensity) = IsDensity()
 DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
 
 @testset "interface" begin
@@ -15,22 +15,22 @@ DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
     @test inverse(densityof) == funcdensity
     @test inverse(funcdensity) == densityof
 
-    @test @inferred(densitykind("foo")) == HasNoDensity
+    @test @inferred(densitykind("foo")) == HasNoDensity()
     @test_throws ArgumentError logdensityof("foo")
     @test_throws ArgumentError densityof("foo")
 
     d1 = MyDensity()
-    @test @inferred(densitykind(d1)) == IsDensity
+    @test @inferred(densitykind(d1)) == IsDensity()
     x = [1, 2, 3]
     DensityInterface.test_density_interface(d1, x, -norm(x)^2)
 
     d2 = logfuncdensity(x -> -norm(x)^2)
-    @test @inferred(densitykind(d2)) == IsDensity
+    @test @inferred(densitykind(d2)) == IsDensity()
     x = [1, 2, 3]
     DensityInterface.test_density_interface(d2, x, -norm(x)^2)
 
     d3 = funcdensity(x -> exp(-norm(x)^2))
-    @test @inferred(densitykind(d3)) == IsDensity
+    @test @inferred(densitykind(d3)) == IsDensity()
     x = [1, 2, 3]
     DensityInterface.test_density_interface(d3, x, -norm(x)^2)
 end

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -5,24 +5,39 @@ using Test
 
 using LinearAlgebra, InverseFunctions
 
+# !!TODO: Add tests for measures!!
 
 struct MyDensity end
 @inline DensityInterface.hasdensity(::MyDensity) = true
-DensityInterface.logdensityof(::MyDensity, x::Any) = norm(x)^2
-
+DensityInterface.logdensityof(::MyDensity, x::Any) = -norm(x)^2
 
 @testset "interface" begin
     @test inverse(logdensityof) == logfuncdensity
     @test inverse(logfuncdensity) == logdensityof
+    @test inverse(densityof) == funcdensity
+    @test inverse(funcdensity) == densityof
 
     @test @inferred(hasdensity("foo")) == false
+    @test @inferred(ismeasure("foo")) == false
+    @test @inferred(isdensity("foo")) == false
     @test_throws ArgumentError logdensityof("foo")
+    @test_throws ArgumentError densityof("foo")
 
     d1 = MyDensity()
+    @test @inferred(ismeasure(d1)) == false
+    @test @inferred(isdensity(d1)) == true
     x = [1, 2, 3]
-    DensityInterface.test_density_interface(d1, x, norm(x)^2)
+    DensityInterface.test_density_interface(d1, x, -norm(x)^2)
 
-    d2 = logfuncdensity(x -> norm(x)^2)
+    d2 = logfuncdensity(x -> -norm(x)^2)
+    @test @inferred(ismeasure(d2)) == false
+    @test @inferred(isdensity(d2)) == true
     x = [1, 2, 3]
-    DensityInterface.test_density_interface(d2, x, norm(x)^2)
+    DensityInterface.test_density_interface(d2, x, -norm(x)^2)
+
+    d3 = funcdensity(x -> exp(-norm(x)^2))
+    @test @inferred(ismeasure(d3)) == false
+    @test @inferred(isdensity(d3)) == true
+    x = [1, 2, 3]
+    DensityInterface.test_density_interface(d3, x, -norm(x)^2)
 end

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -29,7 +29,7 @@ DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
         DensityInterface.test_density_interface(object1, x, -norm(x)^2)
 
         object2 = logfuncdensity(x -> -norm(x)^2)
-        @test DensityKind(object2) == IsDensity()
+        @test DensityKind(object2) === IsDensity()
         DensityInterface.test_density_interface(object2, x, -norm(x)^2)
 
         object3 = funcdensity(x -> exp(-norm(x)^2))


### PR DESCRIPTION
**Updated**

This PR provides a few light-tough improvement on the current API:

* It adds `isdensity` so we can distinguish between things that *are* and that *have* densities. I think this is essential.

* The behavior of `logfuncdensity` is changed for things that *have* a density, it now always returns something that *is* a density. This is saner and essential for proper measure theory semantics. It uses `isdensity` to select behavior.

* It adds `funcdensity` for symmetry. Should have had that in the first place.

* It changes the argument name `d` to `object` in docs and method signatures. It's more neutral and doesn't imply that the argument *is* a density.

* There's less about measure theory in the docs now - can add that to MeasureBase instead, in extended form.
