### PR TITLE
RFQ Add LikelihoodDensity as a typedef for existing implicit likelihood functionality

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,10 +13,18 @@ DocMeta.setdocmeta!(
     :DocTestSetup,
     quote
         using DensityInterface
-        object = logfuncdensity(x -> -x^2)
+        object = logfuncdensity(x -> x^2)
         log_f = logdensityof(object)
         f = densityof(object)
-        x = 4
+        x = 4.2
+
+        struct Normal{T}
+            μ::T
+            σ::T
+        end
+        @inline DensityInterface.DensityKind(::Normal) = HasDensity()
+        DensityInterface.logdensityof(d::Normal, x) = -((x - d.μ)/d.σ)^2/2 - log(d.σ * √(2π))
+
     end;
     recursive=true,
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,6 +21,7 @@ NoDensity
 DensityKind
 DensityInterface.LogFuncDensity
 DensityInterface.FuncDensity
+DensityInterface.LikelihoodDensity
 ```
 
 ## Test utility

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -342,3 +342,53 @@ function Base.show(io::IO, object::FuncDensity)
     show(io, object._f)
     print(io, ")")
 end
+
+
+@static if VERSION >= v"1.6"
+
+"""
+    LikelihoodDensity{F,O}(f_kernel, obs)
+
+Given a kernel function `f_kernel` that generates a distribution or
+measure in general
+
+```jldoctest ld
+julia> f_kernel(x) = Normal(x, 2.0);
+
+julia> DensityKind(f_kernel(x))
+HasDensity()
+```
+
+and an observation `obs` of such a distribution/measure
+
+```jldoctest ld
+julia> obs = 1.5;
+```
+
+a `LikelihoodDensity` behaves in the following way
+
+```jldoctest ld
+julia> likelihood = LikelihoodDensity(f_kernel, obs)
+LikelihoodDensity(f_kernel, 1.5)
+
+julia> DensityKind(likelihood)
+IsDensity()
+
+julia> logdensityof(likelihood, x) == logdensityof(f_kernel(x), obs)
+true
+```
+"""
+const LikelihoodDensity{F,O} = DensityInterface.LogFuncDensity{ComposedFunction{Base.Fix2{typeof(logdensityof), O}, F}}
+export LikelihoodDensity
+
+LikelihoodDensity(k, x) = logfuncdensity(Base.Fix2(logdensityof, x) ∘ (k))
+
+function Base.show(io::IO, object::LikelihoodDensity)
+    print(io, "LikelihoodDensity(")
+    show(io, logdensityof(object).inner)
+    print(io, ", ")
+    show(io, logdensityof(object).outer.x)
+    print(io, ")")
+end
+
+end # if VERSION >= v"1.6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,13 @@ Test.@testset "Package DensityInterface" begin
             log_f = logdensityof(object)
             f = densityof(object)
             x = 4.2
+
+            struct Normal{T}
+                μ::T
+                σ::T
+            end
+            @inline DensityInterface.DensityKind(::Normal) = HasDensity()
+            DensityInterface.logdensityof(d::Normal, x) = -((x - d.μ)/d.σ)^2/2 - log(d.σ * √(2π))
         end;
             recursive=true,
     )

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -13,6 +13,7 @@ struct MyMeasure end
 @inline DensityInterface.DensityKind(::MyMeasure) = HasDensity()
 DensityInterface.logdensityof(::MyMeasure, x::Any) = -norm(x)^2
 
+
 @testset "interface" begin
     @test inverse(logdensityof) == logfuncdensity
     @test inverse(logfuncdensity) == logdensityof


### PR DESCRIPTION
I was looking for a place to define generic likelihood densities and realised that they already exist in DensityInterface in an implicit fashion. This makes them visible and documents them.

CC @devmotion , @cscherrer 