### PR TITLE
Fix codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
         with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
   docs:
     name: Documentation


### PR DESCRIPTION
#23 broke codecov integration: https://github.com/JuliaMath/DensityInterface.jl/actions/runs/8339219371/job/22828516211#step:8:31

The problem is that version 4 of the app does not support tokenless uploads anymore.